### PR TITLE
Add README and initial CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+       - image: circleci/ruby:2.4.1-node-browsers
+    working_directory: ~/api-common-protos-ruby
+    steps:
+      - checkout
+      - run:
+          name: checkout submodules
+          command: git submodule update --init
+      - run:
+          name: install protoc
+          command: |
+            curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /tmp/protoc-${PROTOBUF_VERSION}.zip
+            cd /tmp
+            unzip protoc-${PROTOBUF_VERSION}.zip
+            rm protoc-${PROTOBUF_VERSION}.zip
+            sudo sh -c "mv /tmp/protoc /usr/local/bin/protoc"
+          environment:
+            PROTOBUF_VERSION: 3.6.1
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: bundle install --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: run tests
+          command: bundle exec rake ci
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+## Common Protos Ruby
+
+This repository is a home for the [protocol buffer][protobuf] types which are
+common dependencies throughout the Google API ecosystem, generated for Ruby.
+The protobuf definitions for these generated Ruby classes are provided in the
+[API Common Protos][api-common-protos] repository.
+
+## Using these generated classes
+
+See [googleapis-common-protos](googleapis-common-protos/README.md) and [googleapis-common-protos-types](googleapis-common-protos-types/README.md).
+
+These packages are also available from [rubygems](https://rubygems.org):
+  + https://rubygems.org/gems/googleapis-common-protos
+  + https://rubygems.org/gems/googleapis-common-protos-types

--- a/googleapis-common-protos-types/googleapis-common-protos-types.gemspec
+++ b/googleapis-common-protos-types/googleapis-common-protos-types.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google-protobuf", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/googleapis-common-protos/googleapis-common-protos.gemspec
+++ b/googleapis-common-protos/googleapis-common-protos.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "google-protobuf", "~> 3.0"
   spec.add_dependency "grpc", "~> 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "grpc-tools", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Adding a `README.md` and an initial CI workflow (will likely update to Kokoro later) before releasing new gems.

\cc @blowmage @quartzmo 