### PR TITLE
Release preparation for 1.0.4 and 1.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ To add, remove, or modify the common types in these gems do the following.
       ]
     ```
 
-1. Build the gems as usual:
+1. Update the `CHANGELOG.md`, gem version, and open a release pull request:
+
+   Review and document the changes in each gem's `CHANGELOG.md` along with the version number in the `gemspec`.
+   Create a PR to review the changes. Once it's merged, tag the release with the version number and manually pushing the gem as described below.
+
+1. Build & push the gems as usual:
 
     ```bash
     $ cd googleapis-common-protos-types # or googleapis-common-protos
@@ -48,4 +53,4 @@ To add, remove, or modify the common types in these gems do the following.
     $ bundle exec rake build
     ```
 
-    Finally, double check that the local gem in `pkg` include all of the types before publishing it to Rubygems.
+    Finally, double check that the local gem in `pkg` includes all of the types before publishing it to Rubygems.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To add, remove, or modify the common types in these gems do the following.
 1. Update the `CHANGELOG.md`, gem version, and open a release pull request:
 
    Review and document the changes in each gem's `CHANGELOG.md` along with the version number in the `gemspec`.
-   Create a PR to review the changes. Once it's merged, tag the release with the version number and manually pushing the gem as described below.
+   Create a PR to review the changes. Once it's merged, tag the release with the version number and manually push the gem as described below.
 
 1. Build & push the gems as usual:
 

--- a/googleapis-common-protos-types/CHANGELOG.md
+++ b/googleapis-common-protos-types/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Release History
+
+### 1.0.4 / April 3 2019
+
+* Add WaitOperation RPC to operations_pb.rb and update documentation.
+* Add new common types for:
+  + google/api/resource.proto
+  + google/type/calendar_period.proto
+  + google/type/expr.proto
+  + google/type/fraction.proto
+  + google/type/quaternion.proto
+ 

--- a/googleapis-common-protos-types/CHANGELOG.md
+++ b/googleapis-common-protos-types/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 1.0.4 / April 3 2019
+### 1.0.4 / 2019-04-03
 
 * Add WaitOperation RPC to operations_pb.rb and update documentation.
 * Add new common types for:

--- a/googleapis-common-protos-types/googleapis-common-protos-types.gemspec
+++ b/googleapis-common-protos-types/googleapis-common-protos-types.gemspec
@@ -16,7 +16,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "googleapis-common-protos-types"
-  spec.version       = "1.0.3"
+  spec.version       = "1.0.4"
   spec.authors       = ["Google Inc"]
   spec.email         = ["googleapis-packages@google.com"]
   spec.licenses      = ["Apache-2.0"]

--- a/googleapis-common-protos/CHANGELOG.md
+++ b/googleapis-common-protos/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Release History
+
+### 1.3.9 / April 3 2019
+
+* Add WaitOperation RPC to operations_services_pb.rb and update documentation.

--- a/googleapis-common-protos/CHANGELOG.md
+++ b/googleapis-common-protos/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
 
-### 1.3.9 / April 3 2019
+### 1.3.9 / 2019-04-03
 
 * Add WaitOperation RPC to operations_services_pb.rb and update documentation.

--- a/googleapis-common-protos/googleapis-common-protos.gemspec
+++ b/googleapis-common-protos/googleapis-common-protos.gemspec
@@ -16,7 +16,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "googleapis-common-protos"
-  spec.version       = "1.3.8"
+  spec.version       = "1.3.9"
   spec.authors       = ["Google Inc"]
   spec.email         = ["googleapis-packages@google.com"]
   spec.licenses      = ["Apache-2.0"]


### PR DESCRIPTION
Prepare for the next release. If this PR is approved I'll release these as new patch releases due to the grpc dependency that @blowmage pointed out.