### PR TITLE
chore: Fix version of googleapis-common-protos

### DIFF
--- a/googleapis-common-protos/lib/googleapis/common/protos/version.rb
+++ b/googleapis-common-protos/lib/googleapis/common/protos/version.rb
@@ -16,6 +16,6 @@
 
 module Google
   module CommonProtos
-    VERSION = "1.3.12".freeze
+    VERSION = "1.4.0".freeze
   end
 end


### PR DESCRIPTION
It seems release-please didn't update this properly during the last release (https://github.com/googleapis/common-protos-ruby/pull/78) which is probably why the release didn't go through to rubygems. Fixing so we're in the correct state moving forward. I _think_ the release-please config is correct for this gem, so it _should_ be updating the version file correctly, but we should probably pay attention the next time we do a release just to make sure it does the right thing.