### PR TITLE
build: tag release SHAs with the release-please tag

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -4,3 +4,4 @@ manifest: true
 monorepoTags: true
 primaryBranch: main
 releaseType: ruby-yoshi
+tagPullRequestNumber: true


### PR DESCRIPTION
This is used for triggering Louhi releases for monorepos.