### PR TITLE
chore(ci): secure workflow configuration and resolve zizmor warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: "CI"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -31,11 +34,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "${{ matrix.ruby }}"
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Checkout submodules
         run: |
           git submodule update --init
@@ -43,5 +48,8 @@ jobs:
         run: |
           gem install --no-document toys
       - name: Run CI
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
-          toys ci -v --build --test --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }}
+          toys ci -v --build --test --github-event-name="$GITHUB_EVENT_NAME" --github-event-payload="$GITHUB_EVENT_PATH"

--- a/.github/workflows/new-gem.yml
+++ b/.github/workflows/new-gem.yml
@@ -1,4 +1,8 @@
 name: Create New Gem
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -17,9 +21,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Ruby 3.4
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "3.4"
       - name: Install tools

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -1,4 +1,8 @@
 name: Update Gems
+
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '43 11 * * 0'
@@ -16,9 +20,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Ruby 3.4
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "3.4"
       - name: Install tools


### PR DESCRIPTION
- Set explicit read-only permissions for workflow jobs
- Resolve template injection in CI script by using environment variables
- Disable credential persistence in checkout step to prevent token leakage
- Pin actions to specific commit SHAs and specify exact version tags

Used go/github-zizmor-help?polyglot=github-com#local-scans-run-zizmor-on-your-cloudtop